### PR TITLE
No stubbed mock

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -232,6 +232,9 @@ RSpec/SortMetadata:
 RSpec/SubjectDeclaration:
   Enabled: true
 
+RSpec/StubbedMock:
+  Enabled: false
+
 RSpec/VerifiedDoubleReference:
   Enabled: true
 


### PR DESCRIPTION
Fun rabbit hole of why this is enabled by default (https://github.com/rubocop/rubocop-rspec/issues/1271) [tl;dr no good reason, don't expect reasonable defaults from rubocop]