### PR TITLE
chore: added exclusion to style guard errors

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -133,6 +133,10 @@ Style/FileRead:
 Style/FileWrite:
   Enabled: true
 
+# TODO - remove this when this has been released on rubocop
+Style/GuardClause:
+  Enabled: false
+
 Style/HashConversion:
   Enabled: true
 


### PR DESCRIPTION
N/A

---

Currently blocking. Adding this in because it is causing failures here: https://github.com/rubocop/rubocop/pull/11307

Until this gets released with a fix and we've updated it on our end.

Example failure (that passes with this rule excluded): https://github.com/aptible/aptible-api-v2/actions/runs/3986491217/jobs/6835136768#step:4:254