### PR TITLE
chore: increasing module length to avoid overly guarding behavior

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -343,6 +343,12 @@ Metrics/MethodLength:
   Enabled: true
   Max: 75
 
+# This probably isn't best to change either, but some modules and corresopnding
+# helpers will have a fair number of lines and this seems arbitrarily limiting
+Metrics/ModuleLength:
+  Enabled: true
+  Max: 200
+
 # We may want to re-enable this in the future with a reasonable value,
 # but right now this is overly prescriptive, especially in scenarios
 # where we have a lot of boilerplate code.


### PR DESCRIPTION
Example [failure](https://github.com/aptible/sweetness-v2/actions/runs/4195902432/jobs/7276111201#step:4:216)

<img width="992" alt="image" src="https://user-images.githubusercontent.com/2961973/219706222-e27a2f4a-ff12-447e-85ca-061665b1dea4.png">
