### PR TITLE
Disable numeric Iiteral underscores

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -176,6 +176,9 @@ Style/NumberedParameters:
 Style/NumberedParametersLimit:
   Enabled: true
 
+Style/NumericLiterals:
+  Enabled: false
+
 Style/ObjectThen:
   Enabled: true
 


### PR DESCRIPTION
Disable requiring using underscores as thousands separator. Half the team hates this rule so...