### PR TITLE
Silence a few rubocop errors from deploy-api

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -248,13 +248,13 @@ RSpec/VerifiedDoubleReference:
 Capybara/NegationMatcher:
   Enabled: true
 
-RSpec/Capybara/SpecificActions:
+Capybara/SpecificActions:
   Enabled: true
 
-RSpec/Capybara/SpecificFinders:
+Capybara/SpecificFinders:
   Enabled: true
 
-RSpec/Capybara/SpecificMatcher:
+Capybara/SpecificMatcher:
   Enabled: true
 
 FactoryBot/ConsistentParenthesesStyle:
@@ -263,13 +263,13 @@ FactoryBot/ConsistentParenthesesStyle:
 FactoryBot/SyntaxMethods:
   Enabled: true
 
-RSpec/Rails/AvoidSetupHook:
+RSpecRails/AvoidSetupHook:
   Enabled: true
 
-RSpec/Rails/HaveHttpStatus:
+RSpecRails/HaveHttpStatus:
   Enabled: true
 
-RSpec/Rails/InferredSpecType:
+RSpecRails/InferredSpecType:
   Enabled: true
 
 ###############################################################################


### PR DESCRIPTION
The errors are

```
root@8310f9a60859:/app# bundle exec rubocop
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Capybara/SpecificActions has the wrong namespace - replace it with Capybara/SpecificActions
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Capybara/SpecificFinders has the wrong namespace - replace it with Capybara/SpecificFinders
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Capybara/SpecificMatcher has the wrong namespace - replace it with Capybara/SpecificMatcher
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Rails/AvoidSetupHook has the wrong namespace - replace it with RSpecRails/AvoidSetupHook
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Rails/HaveHttpStatus has the wrong namespace - replace it with RSpecRails/HaveHttpStatus
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-base-yml: RSpec/Rails/InferredSpecType has the wrong namespace - replace it with RSpecRails/InferredSpecType
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-rails-yml: RSpec/Rails/AvoidSetupHook has the wrong namespace - replace it with RSpecRails/AvoidSetupHook
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-rails-yml: RSpec/Rails/HaveHttpStatus has the wrong namespace - replace it with RSpecRails/HaveHttpStatus
.rubocop-https---raw-githubusercontent-com-aptible-dryer-lint-main--rubocop-rails-yml: RSpec/Rails/InferredSpecType has the wrong namespace - replace it with RSpecRails/InferredSpecType
spec/lib/danger_zone/reports_spec.rb: Metrics/LineLength has the wrong namespace - replace it with Layout/LineLength
spec/lib/danger_zone/reports_spec.rb: Metrics/LineLength has the wrong namespace - replace it with Layout/LineLength
```

The dangerzone issues need to be fixed in deploy-api, but otherwise this should silence the others