### PR TITLE
oops: base was accidentally changed

### DIFF
--- a/.rubocop.base.yml
+++ b/.rubocop.base.yml
@@ -245,31 +245,31 @@ RSpec/StubbedMock:
 RSpec/VerifiedDoubleReference:
   Enabled: true
 
-RSpec/Capybara/NegationMatcher:
+Capybara/NegationMatcher:
   Enabled: true
 
-RSpec/Capybara/SpecificActions:
+Capybara/SpecificActions:
   Enabled: true
 
-RSpec/Capybara/SpecificFinders:
+Capybara/SpecificFinders:
   Enabled: true
 
-RSpec/Capybara/SpecificMatcher:
+Capybara/SpecificMatcher:
   Enabled: true
 
-RSpec/FactoryBot/ConsistentParenthesesStyle:
+FactoryBot/ConsistentParenthesesStyle:
   Enabled: true
 
-RSpec/FactoryBot/SyntaxMethods:
+FactoryBot/SyntaxMethods:
   Enabled: true
 
-RSpec/Rails/AvoidSetupHook:
+RSpecRails/AvoidSetupHook:
   Enabled: true
 
-RSpec/Rails/HaveHttpStatus:
+RSpecRails/HaveHttpStatus:
   Enabled: true
 
-RSpec/Rails/InferredSpecType:
+RSpecRails/InferredSpecType:
   Enabled: true
 
 ###############################################################################


### PR DESCRIPTION
#16 and commit f7e9bb3 were intended to leave .rubocop.base.yml as-is, and create new versions in rspec_3_plus/.

But, changes to .rubocop.base.yml were accidentally left in. This undoes that.
